### PR TITLE
Update custom_node.gd argument for Godot4

### DIFF
--- a/addons/jigglebones/custom_node.gd
+++ b/addons/jigglebones/custom_node.gd
@@ -4,7 +4,7 @@ extends EditorPlugin
 func _enter_tree():
 	# Initialization of the plugin goes here
 	# Add the new type with a name, a parent type, a script and an icon
-	add_custom_type("Jigglebone", "Spatial", preload("jigglebone.gd"), preload("icon.svg"))
+	add_custom_type("Jigglebone", "Node3D", preload("jigglebone.gd"), preload("icon.svg"))
 
 func _exit_tree():
 	# Clean-up of the plugin goes here


### PR DESCRIPTION
Wasn't able to see this node when adding nodes to my scene

Correcting the old `Spatial` name to `Node3D` fixed this - appeared as expected and worked perfectly